### PR TITLE
Changed complex data type in table

### DIFF
--- a/igor2/binarywave.py
+++ b/igor2/binarywave.py
@@ -83,7 +83,7 @@ class NullStaticStringField (StaticStringField):
 # From IgorMath.h
 TYPE_TABLE = {        # (key: integer flag, value: numpy dtype)
     0: None,           # Text wave, not handled in ReadWave.c
-    1: _numpy.complex_,  # NT_CMPLX, makes number complex.
+    1: _numpy.complex128,  # NT_CMPLX, makes number complex.
     2: _numpy.float32,  # NT_FP32, 32 bit fp numbers.
     3: _numpy.complex64,
     4: _numpy.float64,  # NT_FP64, 64 bit fp numbers.


### PR DESCRIPTION
This change of data type should make Igor2 compatible with NumPy V2.0, while being backwards compatible down to at least NumPy V1.19. 

Type 1 does not seem to have an actual purpose, but exists due to how the type table was historically structured. It appears that the type number read from files is decremented by 1 when the type is complex. Therefore, type 5 maps to twice type 4 (real and imaginary), type 3 maps two twice type 2, and interestingly, type 1 would be mapped to two text types, which suggests that it doesn't exist at all. At least it is not used in the tests and any IGOR Pro files I encountered. Further evidence for this claim can be found in the MATLAB code found [here](https://mathworks.com/matlabcentral/fileexchange/42679-igor-pro-file-format-ibw-to-matlab-variable?focused=3790756&s_tid=gn_loc_drop&tab=function). For completeness, we map it to `numpy.complex128`, but it appears one could map it to anything - perhaps completely eliminate the statement entirely to avoid future confusion (we don't need an Igor3).

(This ironically makes it all the more painful that this single line of code is the raison d'être of Igor2, as the assigned type in Igor was the cause of compatibility with later NumPy versions.)